### PR TITLE
5ynax development

### DIFF
--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -220,6 +220,7 @@ function Hex-Decode{
 #Convert-ToEpoch: Converts from human readable date and time to Epoch timestamp (All timestamps assume UTC)
 function Convert-ToEpoch{
     [CmdletBinding()]
+    [Alias('ConvertTo-Epoch')]
     param(
         [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)]
         [string] $InputObject
@@ -235,6 +236,7 @@ function Convert-ToEpoch{
 #Convert-FromEpoch: Converts from Epoch timestamp to human readable timestamp (All timestamps assume UTC)
 function Convert-FromEpoch{
     [CmdletBinding()]
+    [Alias('ConvertFrom-Epoch')]
     param(
         [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)]
         [string] $InputObject
@@ -255,6 +257,7 @@ function Convert-FromEpoch{
 #Convert-ToMsftFileTime: Converts from a human readable data and time to Microsoft FileTime timestamp (All timestamps assume UTC)
 function Convert-ToMsftFileTime{
     [CmdletBinding()]
+    [Alias('ConvertTo-MsftFileTime')]
     param(
         [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)]
         [string] $InputObject
@@ -269,6 +272,7 @@ function Convert-ToMsftFileTime{
 #Convert-FromMsftFileTime: Converts from a human readable data and time to Microsoft FileTime timestamp (All timestamps assume UTC)
 function Convert-FromMsftFileTime{
     [CmdletBinding()]
+    [Alias('ConvertFrom-MsftFileTime')]
     param(
         [Parameter(Position=0,Mandatory=$true,ValueFromPipeline=$true)]
         [string] $InputObject

--- a/Microsoft.PowerShell_profile.ps1
+++ b/Microsoft.PowerShell_profile.ps1
@@ -1,7 +1,7 @@
 ########## DFIR PowerShell Profile ##########
 
 $TmpVerbosePreference = $VerbosePreference
-#$VerbosePreference = 'Continue'
+$VerbosePreference = 'Continue'
 
 #--------Begin Configuration Section--------#
 $DefaultConfig = @{
@@ -323,11 +323,11 @@ function WhoIs{
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true,Position=0)][String]$Domain,
-        [String]$APIKey = $Config.XMLAPIKey
+        [Parameter(Mandatory=$false,Position=1)][String]$APIKey=$Config.XMLAPIKey
     )
 
     process {
-
+        
         if (!$APIKey){
 
             throw "No API key detected. Add API key to config file and try again."
@@ -352,8 +352,8 @@ function DNSLookup{
     [CmdletBinding()]
     param (
         [Parameter(Mandatory=$true,Position=0)][String]$Domain,
-        [String]$APIKey = $Config.XMLAPIKey,
-        [string]$Type = '_all'
+        [String]$APIKey=$Config.XMLAPIKey,
+        [string]$Type='_all'
     )
 
     if (!$APIKey){
@@ -385,4 +385,4 @@ function DNSLookup{
 $VerbosePreference = $TmpVerbosePreference
 
 #Clean up created defaultconfig and config variables so they don't appear in session
-Remove-Variable -Name 'Alias','DefaultConfig','Config','Module','TmpVerbosePreference' -Force -ErrorAction 'SilentlyContinue'
+#Remove-Variable -Name 'Alias','DefaultConfig','Config','Module','TmpVerbosePreference' -Force -ErrorAction 'SilentlyContinue'


### PR DESCRIPTION
fixes #40 
Session variable cleanup was causing $APIKey to be removed prematurely. Temporary solution implemented, long term fix coming soon.